### PR TITLE
Session11: スレッドブロック

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,8 @@
     {
       "name": "flutter-training",
       "request": "launch",
-      "type": "dart"
+      "type": "dart",
+      "runTestsOnDevice": true
     },
     {
       "name": "flutter-training (profile mode)",

--- a/lib/controller/weather_controller.dart
+++ b/lib/controller/weather_controller.dart
@@ -10,7 +10,7 @@ WeatherService weatherService(WeatherServiceRef ref) {
 }
 
 @Riverpod(keepAlive: true)
-WeatherResponseModel fetchWeather(
+Future<WeatherResponseModel> fetchWeather(
   FetchWeatherRef ref,
   WeatherParameterModel param,
 ) {
@@ -21,11 +21,17 @@ WeatherResponseModel fetchWeather(
 @riverpod
 class WeatherNotifier extends _$WeatherNotifier {
   @override
-  WeatherResponseModel? build() {
+  FutureOr<WeatherResponseModel?> build() {
     return null;
   }
 
-  void fetch(WeatherParameterModel param) {
-    state = ref.read(fetchWeatherProvider(param));
+  Future<void> fetch(WeatherParameterModel param) async {
+    if (state.isLoading) {
+      return;
+    }
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() {
+      return ref.read(fetchWeatherProvider(param).future);
+    });
   }
 }

--- a/lib/controller/weather_controller.dart
+++ b/lib/controller/weather_controller.dart
@@ -27,7 +27,7 @@ class WeatherNotifier extends _$WeatherNotifier {
 
   Future<void> fetch(WeatherParameterModel param) async {
     if (state.isLoading) {
-      return;
+      return ref.read(fetchWeatherProvider(param).future);
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() {

--- a/lib/controller/weather_controller.dart
+++ b/lib/controller/weather_controller.dart
@@ -27,7 +27,7 @@ class WeatherNotifier extends _$WeatherNotifier {
 
   Future<void> fetch(WeatherParameterModel param) async {
     if (state.isLoading) {
-      return ref.read(fetchWeatherProvider(param).future);
+      return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() {

--- a/lib/controller/weather_controller.g.dart
+++ b/lib/controller/weather_controller.g.dart
@@ -23,7 +23,7 @@ final weatherServiceProvider = Provider<WeatherService>.internal(
 );
 
 typedef WeatherServiceRef = ProviderRef<WeatherService>;
-String _$fetchWeatherHash() => r'357281ae2bc05a3764da092e24ccafc26cc0a975';
+String _$fetchWeatherHash() => r'0ceb785362d74ab1e32d5e200cfde991cffb3166';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -51,7 +51,7 @@ class _SystemHash {
 const fetchWeatherProvider = FetchWeatherFamily();
 
 /// See also [fetchWeather].
-class FetchWeatherFamily extends Family<WeatherResponseModel> {
+class FetchWeatherFamily extends Family<AsyncValue<WeatherResponseModel>> {
   /// See also [fetchWeather].
   const FetchWeatherFamily();
 
@@ -89,7 +89,7 @@ class FetchWeatherFamily extends Family<WeatherResponseModel> {
 }
 
 /// See also [fetchWeather].
-class FetchWeatherProvider extends Provider<WeatherResponseModel> {
+class FetchWeatherProvider extends FutureProvider<WeatherResponseModel> {
   /// See also [fetchWeather].
   FetchWeatherProvider(
     WeatherParameterModel param,
@@ -124,7 +124,7 @@ class FetchWeatherProvider extends Provider<WeatherResponseModel> {
 
   @override
   Override overrideWith(
-    WeatherResponseModel Function(FetchWeatherRef provider) create,
+    FutureOr<WeatherResponseModel> Function(FetchWeatherRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -141,7 +141,7 @@ class FetchWeatherProvider extends Provider<WeatherResponseModel> {
   }
 
   @override
-  ProviderElement<WeatherResponseModel> createElement() {
+  FutureProviderElement<WeatherResponseModel> createElement() {
     return _FetchWeatherProviderElement(this);
   }
 
@@ -159,25 +159,25 @@ class FetchWeatherProvider extends Provider<WeatherResponseModel> {
   }
 }
 
-mixin FetchWeatherRef on ProviderRef<WeatherResponseModel> {
+mixin FetchWeatherRef on FutureProviderRef<WeatherResponseModel> {
   /// The parameter `param` of this provider.
   WeatherParameterModel get param;
 }
 
-class _FetchWeatherProviderElement extends ProviderElement<WeatherResponseModel>
-    with FetchWeatherRef {
+class _FetchWeatherProviderElement
+    extends FutureProviderElement<WeatherResponseModel> with FetchWeatherRef {
   _FetchWeatherProviderElement(super.provider);
 
   @override
   WeatherParameterModel get param => (origin as FetchWeatherProvider).param;
 }
 
-String _$weatherNotifierHash() => r'317db339e9d9ef43b1320f5efd7140994186acde';
+String _$weatherNotifierHash() => r'1bed60cb7366d3996ca99579ae6de8d586a7987f';
 
 /// See also [WeatherNotifier].
 @ProviderFor(WeatherNotifier)
-final weatherNotifierProvider = AutoDisposeNotifierProvider<WeatherNotifier,
-    WeatherResponseModel?>.internal(
+final weatherNotifierProvider = AutoDisposeAsyncNotifierProvider<
+    WeatherNotifier, WeatherResponseModel?>.internal(
   WeatherNotifier.new,
   name: r'weatherNotifierProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -187,6 +187,6 @@ final weatherNotifierProvider = AutoDisposeNotifierProvider<WeatherNotifier,
   allTransitiveDependencies: null,
 );
 
-typedef _$WeatherNotifier = AutoDisposeNotifier<WeatherResponseModel?>;
+typedef _$WeatherNotifier = AutoDisposeAsyncNotifier<WeatherResponseModel?>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:isolate';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_training/model/weather_error.dart';
 import 'package:flutter_training/model/weather_model.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -17,9 +17,7 @@ class WeatherService {
 
   Future<String> _request(String jsonString) async {
     try {
-      final response = await Isolate.run(() {
-        return _client.syncFetchWeather(jsonString);
-      });
+      final response = await compute(_client.syncFetchWeather, jsonString);
       return response;
     } on YumemiWeatherError catch (e) {
       switch (e) {

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 
 import 'package:flutter_training/model/weather_error.dart';
 import 'package:flutter_training/model/weather_model.dart';
@@ -14,9 +15,11 @@ class WeatherService {
     return jsonEncode(model.toJson());
   }
 
-  String _request(String jsonString) {
+  Future<String> _request(String jsonString) async {
     try {
-      final response = _client.fetchWeather(jsonString);
+      final response = await Isolate.run(() {
+        return _client.syncFetchWeather(jsonString);
+      });
       return response;
     } on YumemiWeatherError catch (e) {
       switch (e) {
@@ -42,9 +45,9 @@ class WeatherService {
     }
   }
 
-  WeatherResponseModel fetch(WeatherParameterModel model) {
+  Future<WeatherResponseModel> fetch(WeatherParameterModel model) async {
     final jsonString = _serialize(model);
-    final raw = _request(jsonString);
+    final raw = await _request(jsonString);
     return _deserialize(raw);
   }
 }

--- a/lib/view/weather.dart
+++ b/lib/view/weather.dart
@@ -23,6 +23,7 @@ class WeatherScreen extends ConsumerWidget {
         case AsyncLoading():
           await showDialog<void>(
             context: context,
+            barrierDismissible: false,
             builder: (context) {
               return const Center(child: CircularProgressIndicator());
             },

--- a/lib/view/weather.dart
+++ b/lib/view/weather.dart
@@ -44,7 +44,6 @@ class WeatherScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final weatherResponse = ref.watch(weatherNotifierProvider);
-
     return Scaffold(
       body: Center(
         child: FractionallySizedBox(
@@ -54,15 +53,17 @@ class WeatherScreen extends ConsumerWidget {
               const Spacer(),
               AspectRatio(
                 aspectRatio: 1,
-                child: weatherResponse != null
-                    ? WeatherIcon(weatherType: weatherResponse.weatherCondition)
-                    : const Placeholder(),
+                child: switch (weatherResponse) {
+                  AsyncValue(:final WeatherResponseModel value) =>
+                    WeatherIcon(weatherType: value.weatherCondition),
+                  _ => const Placeholder()
+                },
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 child: Temperature(
-                  minTemperature: weatherResponse?.minTemperature,
-                  maxTemperature: weatherResponse?.maxTemperature,
+                  minTemperature: weatherResponse.valueOrNull?.minTemperature,
+                  maxTemperature: weatherResponse.valueOrNull?.maxTemperature,
                 ),
               ),
               Flexible(

--- a/test/controller/weather_controller_test.dart
+++ b/test/controller/weather_controller_test.dart
@@ -26,27 +26,27 @@ void main() {
       ],
     );
     addTearDown(container.dispose);
-    when(mock.fetch(any)).thenReturn(response);
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
-    container.read(weatherNotifierProvider.notifier).fetch(param);
+    await container.read(weatherNotifierProvider.notifier).fetch(param);
 
     verify(mock.fetch(any)).called(1);
   });
 
-  test('controllerのfetchが呼び出されたとき, Notifierの値が更新される', () {
+  test('controllerのfetchが呼び出されたとき, Notifierの値が更新される', () async {
     final container = ProviderContainer(
       overrides: [
         weatherServiceProvider.overrideWithValue(mock),
       ],
     );
     addTearDown(container.dispose);
-    when(mock.fetch(any)).thenReturn(response);
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
     final value1 = container.read(weatherNotifierProvider);
-    expect(value1, null);
+    expect(value1.value, null);
 
-    container.read(weatherNotifierProvider.notifier).fetch(param);
+    await container.read(weatherNotifierProvider.notifier).fetch(param);
     final value2 = container.read(weatherNotifierProvider);
-    expect(value2, response);
+    expect(value2.value, response);
   });
 }

--- a/test/controller/weather_controller_test.dart
+++ b/test/controller/weather_controller_test.dart
@@ -79,27 +79,11 @@ void main() {
     completer.complete(response);
     await container.read(weatherNotifierProvider.notifier).fetch(param);
 
-    // ローディング中の実行だがFutureの終了を待機する
+    // Future が終了した後の実行
     final value3 = container.read(weatherNotifierProvider);
     expect(value3.isLoading, false);
 
     verify(mock.fetch(any)).called(1);
-  });
-
-  test('controllerのfetchは更新時にAsyncLoadingになっているか', () async {
-    final mock = MockWeatherService();
-    final container = ProviderContainer(
-      overrides: [
-        weatherServiceProvider.overrideWithValue(mock),
-      ],
-    );
-    addTearDown(container.dispose);
-    final completer = Completer<WeatherResponseModel>();
-    when(mock.fetch(any)).thenAnswer((_) => completer.future);
-
-    unawaited(container.read(weatherNotifierProvider.notifier).fetch(param));
-    final value = container.read(weatherNotifierProvider);
-    expect(value.isLoading, true);
   });
 
   test('controllerのfetchで例外が発生したとき', () async {

--- a/test/controller/weather_controller_test.dart
+++ b/test/controller/weather_controller_test.dart
@@ -86,7 +86,7 @@ void main() {
     verify(mock.fetch(any)).called(1);
   });
 
-  test('controllerのfetchで例外が発生したとき', () async {
+  test('WeatherService.fetchで例外が発生したとき', () async {
     final mock = MockWeatherService();
     final container = ProviderContainer(
       overrides: [

--- a/test/controller/weather_controller_test.mocks.dart
+++ b/test/controller/weather_controller_test.mocks.dart
@@ -3,6 +3,8 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i4;
+
 import 'package:flutter_training/model/weather_model.dart' as _i2;
 import 'package:flutter_training/service/weather_service.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -36,25 +38,28 @@ class _FakeWeatherResponseModel_0 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherService extends _i1.Mock implements _i3.WeatherService {
   @override
-  _i2.WeatherResponseModel fetch(_i2.WeatherParameterModel? model) =>
+  _i4.Future<_i2.WeatherResponseModel> fetch(
+          _i2.WeatherParameterModel? model) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetch,
           [model],
         ),
-        returnValue: _FakeWeatherResponseModel_0(
+        returnValue: _i4.Future<_i2.WeatherResponseModel>.value(
+            _FakeWeatherResponseModel_0(
           this,
           Invocation.method(
             #fetch,
             [model],
           ),
-        ),
-        returnValueForMissingStub: _FakeWeatherResponseModel_0(
+        )),
+        returnValueForMissingStub: _i4.Future<_i2.WeatherResponseModel>.value(
+            _FakeWeatherResponseModel_0(
           this,
           Invocation.method(
             #fetch,
             [model],
           ),
-        ),
-      ) as _i2.WeatherResponseModel);
+        )),
+      ) as _i4.Future<_i2.WeatherResponseModel>);
 }

--- a/test/service/weather_service_test.dart
+++ b/test/service/weather_service_test.dart
@@ -26,50 +26,50 @@ void main() {
       date: DateTime.parse('2024-08-07T14:54:04+09:00'),
     );
 
-    when(mock.fetchWeather(any)).thenReturn(jsonString);
-    final value = service.fetch(param);
+    when(mock.syncFetchWeather(any)).thenReturn(jsonString);
+    final value = await service.fetch(param);
 
-    verify(mock.fetchWeather(any)).called(1);
     expect(value, model);
   });
 
-  test('APIにInvalidParameterエラーが発生したとき', () {
-    when(mock.fetchWeather(any)).thenThrow(YumemiWeatherError.invalidParameter);
+  test('APIにInvalidParameterエラーが発生したとき', () async {
+    when(mock.syncFetchWeather(any))
+        .thenThrow(YumemiWeatherError.invalidParameter);
     expect(
-      () => service.fetch(param),
-      throwsA(const TypeMatcher<WeatherInvalidParameterException>()),
+      service.fetch(param),
+      throwsA(isA<WeatherInvalidParameterException>()),
     );
   });
 
-  test('APIにUnknownエラーが発生したとき', () {
-    when(mock.fetchWeather(any)).thenThrow(YumemiWeatherError.unknown);
+  test('APIにUnknownエラーが発生したとき', () async {
+    when(mock.syncFetchWeather(any)).thenThrow(YumemiWeatherError.unknown);
     expect(
-      () => service.fetch(param),
-      throwsA(const TypeMatcher<WeatherUnknownException>()),
+      service.fetch(param),
+      throwsA(isA<WeatherUnknownException>()),
     );
   });
 
-  test('APIがJSON以外の応答を返したとき', () {
-    when(mock.fetchWeather(any)).thenReturn('hello world!');
+  test('APIがJSON以外の応答を返したとき', () async {
+    when(mock.syncFetchWeather(any)).thenReturn('hello world!');
     expect(
-      () => service.fetch(param),
-      throwsA(const TypeMatcher<WeatherInvalidResponseException>()),
+      service.fetch(param),
+      throwsA(isA<WeatherInvalidResponseException>()),
     );
   });
 
-  test('APIがJSONを返したが、トップレベルがMAPではないとき', () {
-    when(mock.fetchWeather(any)).thenReturn('"hello world!"');
+  test('APIがJSONを返したが、トップレベルがMAPではないとき', () async {
+    when(mock.syncFetchWeather(any)).thenReturn('"hello world!"');
     expect(
       () => service.fetch(param),
-      throwsA(const TypeMatcher<WeatherInvalidResponseException>()),
+      throwsA(isA<WeatherInvalidResponseException>()),
     );
   });
 
-  test('APIが異なるJSONフォーマットを返したとき', () {
-    when(mock.fetchWeather(any)).thenReturn('{"key":"value"}');
+  test('APIが異なるJSONフォーマットを返したとき', () async {
+    when(mock.syncFetchWeather(any)).thenReturn('{"key":"value"}');
     expect(
       () => service.fetch(param),
-      throwsA(const TypeMatcher<WeatherInvalidResponseException>()),
+      throwsA(isA<WeatherInvalidResponseException>()),
     );
   });
 }

--- a/test/test_util/finder.dart
+++ b/test/test_util/finder.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,4 +13,23 @@ extension CommonFindersExt on CommonFinders {
     });
     return finder;
   }
+}
+
+class FakeFuture<T> {
+  FakeFuture(this.any) : completer = Completer<T>();
+
+  static void call<T>(T any, void Function(Future<T>) e) {
+    final fake = FakeFuture(any);
+    e(fake.future);
+    fake.complete();
+  }
+
+  void complete() {
+    completer.complete(any);
+  }
+
+  Future<T> get future => completer.future;
+
+  final Completer<T> completer;
+  final T any;
 }

--- a/test/test_util/finder.dart
+++ b/test/test_util/finder.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,23 +11,4 @@ extension CommonFindersExt on CommonFinders {
     });
     return finder;
   }
-}
-
-class FakeFuture<T> {
-  FakeFuture(this.any) : completer = Completer<T>();
-
-  static void call<T>(T any, void Function(Future<T>) e) {
-    final fake = FakeFuture(any);
-    e(fake.future);
-    fake.complete();
-  }
-
-  void complete() {
-    completer.complete(any);
-  }
-
-  Future<T> get future => completer.future;
-
-  final Completer<T> completer;
-  final T any;
 }

--- a/test/view/weather_robot.dart
+++ b/test/view/weather_robot.dart
@@ -21,8 +21,8 @@ class WeatherScreenRobot extends Robot<WeatherScreen> {
       find.descendant(of: find.byType(Dialog), matching: find.text(text));
 
   Future<void> show({required List<Override> overrides}) async {
-    tester.view.devicePixelRatio = 1;
-    tester.view.physicalSize = const Size(2400, 1600);
+    await tester.binding.setSurfaceSize(const Size(375, 790));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpWidget(
       ProviderScope(
         overrides: overrides,

--- a/test/view/weather_test.dart
+++ b/test/view/weather_test.dart
@@ -21,12 +21,11 @@ void main() {
 
   testWidgets('気温が表示されているかどうか', (tester) async {
     final robot = WeatherScreenRobot(tester);
-    when(mock.fetch(any)).thenReturn(
-      baseResponse.copyWith(
-        maxTemperature: 10,
-        minTemperature: -10,
-      ),
+    final response = baseResponse.copyWith(
+      maxTemperature: 10,
+      minTemperature: -10,
     );
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
     await robot.show(
       overrides: [
@@ -41,11 +40,10 @@ void main() {
 
   testWidgets('sunnyが表示されているかどうか', (tester) async {
     final robot = WeatherScreenRobot(tester);
-    when(mock.fetch(any)).thenReturn(
-      baseResponse.copyWith(
-        weatherCondition: WeatherType.sunny,
-      ),
+    final response = baseResponse.copyWith(
+      weatherCondition: WeatherType.sunny,
     );
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
     await robot.show(
       overrides: [
@@ -59,11 +57,10 @@ void main() {
 
   testWidgets('cloudyが表示されているかどうか', (tester) async {
     final robot = WeatherScreenRobot(tester);
-    when(mock.fetch(any)).thenReturn(
-      baseResponse.copyWith(
-        weatherCondition: WeatherType.cloudy,
-      ),
+    final response = baseResponse.copyWith(
+      weatherCondition: WeatherType.cloudy,
     );
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
     await robot.show(
       overrides: [
@@ -77,11 +74,10 @@ void main() {
 
   testWidgets('rainyが表示されているかどうか', (tester) async {
     final robot = WeatherScreenRobot(tester);
-    when(mock.fetch(any)).thenReturn(
-      baseResponse.copyWith(
-        weatherCondition: WeatherType.rainy,
-      ),
+    final response = baseResponse.copyWith(
+      weatherCondition: WeatherType.rainy,
     );
+    when(mock.fetch(any)).thenAnswer((_) async => response);
 
     await robot.show(
       overrides: [

--- a/test/view/weather_test.mocks.dart
+++ b/test/view/weather_test.mocks.dart
@@ -3,6 +3,8 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i4;
+
 import 'package:flutter_training/model/weather_model.dart' as _i2;
 import 'package:flutter_training/service/weather_service.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
@@ -36,25 +38,28 @@ class _FakeWeatherResponseModel_0 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherService extends _i1.Mock implements _i3.WeatherService {
   @override
-  _i2.WeatherResponseModel fetch(_i2.WeatherParameterModel? model) =>
+  _i4.Future<_i2.WeatherResponseModel> fetch(
+          _i2.WeatherParameterModel? model) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetch,
           [model],
         ),
-        returnValue: _FakeWeatherResponseModel_0(
+        returnValue: _i4.Future<_i2.WeatherResponseModel>.value(
+            _FakeWeatherResponseModel_0(
           this,
           Invocation.method(
             #fetch,
             [model],
           ),
-        ),
-        returnValueForMissingStub: _FakeWeatherResponseModel_0(
+        )),
+        returnValueForMissingStub: _i4.Future<_i2.WeatherResponseModel>.value(
+            _FakeWeatherResponseModel_0(
           this,
           Invocation.method(
             #fetch,
             [model],
           ),
-        ),
-      ) as _i2.WeatherResponseModel);
+        )),
+      ) as _i4.Future<_i2.WeatherResponseModel>);
 }


### PR DESCRIPTION
## 課題

close #12

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を `fetchWeather()` から `syncFetchWeather()` に変更する
- [x] API の処理が戻るまで [CircularProgressIndicator] を表示する


## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| ![demo]      | ![画面収録 2024-08-23 13 26 36](https://github.com/user-attachments/assets/4102e849-8ced-47b6-9d5e-669378e74f4b)    |



[demo]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/thread_block/demo.gif?raw=true
